### PR TITLE
First version supporting ufuncs in FDataGrid

### DIFF
--- a/fda/grid.py
+++ b/fda/grid.py
@@ -965,7 +965,7 @@ class FDataGrid(FData):
                          if output is None else output)
                         for result, output in zip(results, new_outputs))
 
-        results = [FDataGrid(data_matrix=r, sample_points=self.sample_points) for r in results]
+        results = [self.copy(data_matrix=r) for r in results]
 
         return results[0] if len(results) == 1 else results
 

--- a/fda/grid.py
+++ b/fda/grid.py
@@ -935,3 +935,37 @@ class FDataGrid(FData):
 
         else:
             return self.copy(data_matrix=self.data_matrix[key])
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+
+        for i in inputs:
+            if isinstance(i, FDataGrid) and not numpy.all(i.sample_points ==
+                                                          self.sample_points):
+                return NotImplemented
+
+        new_inputs = [i.data_matrix if isinstance(i, FDataGrid)
+                      else i for i in inputs]
+
+        outputs = kwargs.pop('out', None)
+        if outputs:
+            new_outputs = [o.data_matrix if isinstance(o, FDataGrid)
+                           else o for o in outputs]
+            kwargs['out'] = tuple(new_outputs)
+        else:
+            new_outputs = (None,) * ufunc.nout
+
+        results = getattr(ufunc, method)(*new_inputs, **kwargs)
+        if results is NotImplemented:
+            return NotImplemented
+
+        if ufunc.nout == 1:
+            results = (results,)
+
+        results = tuple((result
+                         if output is None else output)
+                        for result, output in zip(results, new_outputs))
+
+        results = [FDataGrid(data_matrix=r, sample_points=self.sample_points) for r in results]
+
+        return results[0] if len(results) == 1 else results
+


### PR DESCRIPTION
The purpose of this PR is to add support for numpy ufuncs in FDataGrid objects. With this PR, code such as:
```
import fda

a = fda.datasets.make_gaussian_process()
b = np.sin(a)
```
is valid, and some functions in the math module can be removed (but this PR does not remove them right now).

I would want to discuss several topics related with the current and future implementations:
- FDataGrid matrix mutability. As discussed before, matrix mutability is a problem, as it requires us to detect changes and change the interpolation object, for example. Some ufuncs modify the input arrays, and also FDatagrid objects can be passed as `out` parameters. We should think about the best way to deal with that.
- Operations as ufuncs. Maybe it is useful to change operations such as sum and multiplication to call the corresponding ufunc, after changing types if necessary.
- Removing the obsolete math functions.