### PR TITLE
Added new types of plot

### DIFF
--- a/fda/functional_data.py
+++ b/fda/functional_data.py
@@ -1110,7 +1110,7 @@ class FData(ABC):
 
                 for k in range(self.nsamples):
                     if sample_labels is None and next_color:
-                        sample_colors[j] = axis._get_lines.get_next_color()
+                        sample_colors[k] = axis._get_lines.get_next_color()
 
                     if i == j:
 


### PR DESCRIPTION
Added to the API some types of plot I'm using in my B's resume. Added argument type to the plot 
function, now the curves can be plotted as parametric form or as a pairs plot.

```Python
 a = fda.datasets.make_multimodal_samples(ndim_image=2)
 b = fda.datasets.make_multimodal_samples(ndim_image=3)
```
* Graph plot (current plot). 
```Python
 a.plot()
 b.plot()
```
![2-graph](https://user-images.githubusercontent.com/16774925/55690572-99fbee80-5993-11e9-8d25-ecc8d56e9688.png)
![3-graph](https://user-images.githubusercontent.com/16774925/55690576-a08a6600-5993-11e9-9e41-c3c0c1e7c2e4.png)
* Parametric plot. 
```Python
 a.plot(type="parametric")
 b.plot(type="parametric")
```
![2-param](https://user-images.githubusercontent.com/16774925/55690604-0676ed80-5994-11e9-9741-b16309df3aa0.png)
![3-param](https://user-images.githubusercontent.com/16774925/55690606-0d056500-5994-11e9-994a-d38dea1c410e.png)
* Pairs plot. 
```Python
 a.plot(type="pairs")
 b.plot(type="pairs")
```
![2-pairs](https://user-images.githubusercontent.com/16774925/55690613-1db5db00-5994-11e9-8283-40e4827d8ac4.png)
![3-pairs](https://user-images.githubusercontent.com/16774925/55690614-24445280-5994-11e9-839a-bd8f62f0f8c6.png)
