### PR TITLE
Test changes to avoid failure with other numpy versions

### DIFF
--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -12,7 +12,7 @@ class TestBasis(unittest.TestCase):
         t = np.linspace(0, 1, 5)
         x = np.sin(2 * np.pi * t) + np.cos(2 * np.pi * t)
         basis = BSpline((0, 1), nbasis=5)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             FDataBasis.from_data(x, t, basis, smoothness_parameter=10,
                                  penalty_degree=2, method='cholesky'
                                  ).coefficients.round(2),
@@ -23,7 +23,7 @@ class TestBasis(unittest.TestCase):
         t = np.linspace(0, 1, 5)
         x = np.sin(2 * np.pi * t) + np.cos(2 * np.pi * t)
         basis = BSpline((0, 1), nbasis=5)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             FDataBasis.from_data(x, t, basis, smoothness_parameter=10,
                                  penalty_degree=2, method='qr'
                                  ).coefficients.round(2),
@@ -40,12 +40,12 @@ class TestBasis(unittest.TestCase):
                                   penalty_degree=2,
                                   smoothness_parameter=1)
         # These results where extracted from the R package fda
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             fd.coefficients.round(2), np.array([[0.61, -0.88, 0.06, 0.02]]))
 
     def test_bspline_penalty_special_case(self):
         basis = BSpline(nbasis=5)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             basis.penalty(basis.order - 1),
             np.array([[1152., -2016., 1152., -288., 0.],
                       [-2016., 3600., -2304., 1008., -288.],
@@ -55,7 +55,7 @@ class TestBasis(unittest.TestCase):
 
     def test_fourier_penalty(self):
         basis = Fourier(nbasis=5)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             basis.penalty(2).round(2),
             np.array([[0., 0., 0., 0., 0.],
                       [0., 1558.55, 0., 0., 0.],
@@ -65,7 +65,7 @@ class TestBasis(unittest.TestCase):
 
     def test_bspline_penalty(self):
         basis = BSpline(nbasis=5)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             basis.penalty(2).round(2),
             np.array([[96., -132., 24., 12., 0.],
                       [-132., 192., -48., -24., 12.],
@@ -75,7 +75,7 @@ class TestBasis(unittest.TestCase):
 
     def test_bspline_penalty_numerical(self):
         basis = BSpline(nbasis=5)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             basis.penalty(coefficients=[0, 0, 1]).round(2),
             np.array([[96., -132., 24., 12., 0.],
                       [-132., 192., -48., -24., 12.],
@@ -128,7 +128,7 @@ class TestBasis(unittest.TestCase):
     def test_basis_basis_inprod(self):
         monomial = Monomial(nbasis=4)
         bspline = BSpline(nbasis=5, order=4)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             monomial.inner_product(bspline).round(3),
             np.array(
                 [[0.12499983, 0.25000035, 0.24999965, 0.25000035, 0.12499983],
@@ -143,7 +143,7 @@ class TestBasis(unittest.TestCase):
         bspline = BSpline(nbasis=5, order=3)
         bsplinefd = FDataBasis(bspline, np.arange(0, 15).reshape(3, 5))
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             monomial.inner_product(bsplinefd).round(3),
             np.array([[2., 7., 12.],
                       [1.29626206, 3.79626206, 6.29626206],
@@ -161,7 +161,7 @@ class TestBasis(unittest.TestCase):
         bspline = BSpline(nbasis=5, order=3)
         bsplinefd = FDataBasis(bspline, np.arange(0, 15).reshape(3, 5))
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             monomialfd.inner_product(bsplinefd).round(3),
             np.array([[16.14797697, 52.81464364, 89.4813103],
                       [11.55565285, 38.22211951, 64.88878618],
@@ -175,7 +175,7 @@ class TestBasis(unittest.TestCase):
         bspline = BSpline(nbasis=5, order=3)
         bsplinefd = FDataBasis(bspline, np.arange(0, 15).reshape(3, 5))
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             bsplinefd.inner_product(monomial).round(3),
             np.transpose(monomial.inner_product(bsplinefd).round(3))
         )

--- a/tests/test_basis_evaluation.py
+++ b/tests/test_basis_evaluation.py
@@ -17,11 +17,13 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
-        res = np.array([0.905482867989282, 0.146814813180645, -1.04995054116993, 0.905482867989282, 0.302725561229459,
-                        0.774764356993855, -1.02414754822331, 0.302725561229459]).reshape((2, 4)).round(3)
+        res = np.array([0.905482867989282, 0.146814813180645, -1.04995054116993,
+                        0.905482867989282, 0.302725561229459,
+                        0.774764356993855, -1.02414754822331, 0.302725561229459]
+                       ).reshape((2, 4)).round(3)
 
-        np.testing.assert_array_equal(f(t).round(3), res)
-        np.testing.assert_array_equal(f.evaluate(t).round(3), res)
+        np.testing.assert_array_almost_equal(f(t).round(3), res)
+        np.testing.assert_array_almost_equal(f.evaluate(t).round(3), res)
 
     def test_evaluation_point_fourier(self):
         """Test the evaluation of a single point FDataBasis"""
@@ -33,15 +35,16 @@ class TestBasisEvaluationFourier(unittest.TestCase):
         f = FDataBasis(fourier, coefficients)
 
         # Test different ways of call f with a point
-        res = np.array([-0.903918107989282, -0.267163981229459]).reshape((2, 1)).round(4)
+        res = np.array([-0.903918107989282, -0.267163981229459]
+                       ).reshape((2, 1)).round(4)
 
-        np.testing.assert_array_equal(f([0.5]).round(4), res)
-        np.testing.assert_array_equal(f((0.5,)).round(4), res)
-        np.testing.assert_array_equal(f(0.5).round(4), res)
-        np.testing.assert_array_equal(f(np.array([0.5])).round(4), res)
+        np.testing.assert_array_almost_equal(f([0.5]).round(4), res)
+        np.testing.assert_array_almost_equal(f((0.5,)).round(4), res)
+        np.testing.assert_array_almost_equal(f(0.5).round(4), res)
+        np.testing.assert_array_almost_equal(f(np.array([0.5])).round(4), res)
 
         # Problematic case, should be accepted or no?
-        #np.testing.assert_array_equal(f(np.array(0.5)).round(4), res)
+        #np.testing.assert_array_almost_equal(f(np.array(0.5)).round(4), res)
 
     def test_evaluation_derivative_fourier(self):
         """Test the evaluation of the derivative of a FDataBasis"""
@@ -54,10 +57,12 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
-        res = np.array([4.34138447771721, -7.09352774867064, 2.75214327095343, 4.34138447771721, 6.52573053999253,
-                        -4.81336320468984, -1.7123673353027, 6.52573053999253]).reshape((2, 4)).round(3)
+        res = np.array([4.34138447771721, -7.09352774867064, 2.75214327095343,
+                        4.34138447771721, 6.52573053999253,
+                        -4.81336320468984, -1.7123673353027, 6.52573053999253]
+                       ).reshape((2, 4)).round(3)
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             f(t, derivative=1).round(3), res
         )
 
@@ -76,10 +81,11 @@ class TestBasisEvaluationFourier(unittest.TestCase):
         res_test = f(t)
 
         # Different ways to pass the axes
-        np.testing.assert_array_equal(f(t, grid=True), res_test)
-        np.testing.assert_array_equal(f((t,), grid=True), res_test)
-        np.testing.assert_array_equal(f([t], grid=True), res_test)
-        np.testing.assert_array_equal(f(np.atleast_2d(t), grid=True), res_test)
+        np.testing.assert_array_almost_equal(f(t, grid=True), res_test)
+        np.testing.assert_array_almost_equal(f((t,), grid=True), res_test)
+        np.testing.assert_array_almost_equal(f([t], grid=True), res_test)
+        np.testing.assert_array_almost_equal(f(np.atleast_2d(t), grid=True),
+                                             res_test)
 
         # Number of axis different than the domain dimension (1)
         with np.testing.assert_raises(ValueError):
@@ -100,19 +106,18 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
         # Test same result than evaluation standart
         np.testing.assert_array_almost_equal(f([1]), f([[1], [1]],
-                                                aligned_evaluation=False))
+                                                       aligned_evaluation=False))
         np.testing.assert_array_almost_equal(f(t), f(np.vstack((t, t)),
-                                              aligned_evaluation=False))
+                                                     aligned_evaluation=False))
 
         # Different evaluation times
         t_multiple = [[0, 0.5], [0.2, 0.7]]
         np.testing.assert_array_almost_equal(f(t_multiple[0])[0],
-                                      f(t_multiple,
-                                        aligned_evaluation=False)[0])
+                                             f(t_multiple,
+                                               aligned_evaluation=False)[0])
         np.testing.assert_array_almost_equal(f(t_multiple[1])[1],
-                                      f(t_multiple,
-                                        aligned_evaluation=False)[1])
-
+                                             f(t_multiple,
+                                               aligned_evaluation=False)[1])
 
     def test_evaluation_keepdims_fourier(self):
         """Test behaviour of keepdims """
@@ -129,23 +134,29 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
-        res = np.array([0.905482867989282, 0.146814813180645, -1.04995054116993, 0.905482867989282, 0.302725561229459,
-                        0.774764356993855, -1.02414754822331, 0.302725561229459]).reshape((2, 4)).round(3)
+        res = np.array([0.905482867989282, 0.146814813180645, -1.04995054116993,
+                        0.905482867989282, 0.302725561229459,
+                        0.774764356993855, -1.02414754822331, 0.302725561229459]
+                       ).reshape((2, 4)).round(3)
 
         res_keepdims = res.reshape((2, 4, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t).round(3), res)
-        np.testing.assert_array_equal(f(t, keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f(t, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f(t).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f(t, keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, keepdims=True).round(3),
+                                             res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t).round(3), res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, keepdims=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f_keepdims(t, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t).round(3), res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t, keepdims=False
+                                                        ).round(3),
+                                             res)
+        np.testing.assert_array_almost_equal(f_keepdims(t, keepdims=True
+                                                        ).round(3),
+                                             res_keepdims)
 
     def test_evaluation_composed_keepdims_fourier(self):
         """Test behaviour of keepdims with composed evaluation"""
@@ -162,30 +173,34 @@ class TestBasisEvaluationFourier(unittest.TestCase):
         res = np.array([[0.69173518, -0.69017042, -1.08997978],
                         [0.60972512, -0.57416354,  1.02551401]]).round(3)
 
-        res = np.array([0.905482867989282, -0.903918107989282, -1.13726755517372, 1.09360302608278,
-                        -1.05804144608278, 0.85878105128844]).reshape((2, 3)).round(3)
+        res = np.array([0.905482867989282, -0.903918107989282,
+                        -1.13726755517372, 1.09360302608278,
+                        -1.05804144608278, 0.85878105128844]
+                       ).reshape((2, 3)).round(3)
 
         res_keepdims = res.reshape((2, 3, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
-                                        keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
-                                        keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False
+                                               ).round(3),
+                                             res)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
+                                               keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
+                                               keepdims=True).round(3),
+                                             res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False
-                                                 ).round(3),
-                                      res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False,
-                                                 keepdims=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False,
-                                                 keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t,
+                                                        aligned_evaluation=False
+                                                        ).round(3),
+                                             res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, aligned_evaluation=False, keepdims=False).round(3),
+            res)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, aligned_evaluation=False, keepdims=True).round(3),
+            res_keepdims)
 
     def test_evaluation_grid_keepdims_fourier(self):
         """Test behaviour of keepdims with grid evaluation"""
@@ -203,27 +218,33 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
-        res = np.array([0.905482867989282, 0.146814813180645, -1.04995054116993, 0.905482867989282, 0.302725561229459,
-                        0.774764356993855, -1.02414754822331, 0.302725561229459]).reshape((2, 4)).round(3)
+        res = np.array([0.905482867989282, 0.146814813180645, -1.04995054116993,
+                        0.905482867989282, 0.302725561229459,
+                        0.774764356993855, -1.02414754822331, 0.302725561229459]
+                       ).reshape((2, 4)).round(3)
 
         res_keepdims = res.reshape((2, 4, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t, grid=True).round(3), res)
-        np.testing.assert_array_equal(f(t, grid=True, keepdims=False).round(3),
-                                      res)
+        np.testing.assert_array_almost_equal(f(t, grid=True).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, grid=True, keepdims=False
+                                               ).round(3),
+                                             res)
 
-        np.testing.assert_array_equal(f(t,  grid=True, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f(t,  grid=True, keepdims=True
+                                               ).round(3),
+                                             res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t, grid=True).round(3),
-                                      res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, grid=True,
-                                                 keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f_keepdims(t, grid=True,
-                                                 keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t, grid=True
+                                                        ).round(3),
+                                             res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t, grid=True,
+                                                        keepdims=False
+                                                        ).round(3), res)
+        np.testing.assert_array_almost_equal(f_keepdims(t, grid=True,
+                                                        keepdims=True).round(3),
+                                             res_keepdims)
 
     def test_domain_in_list_fourier(self):
         """Test the evaluation of FDataBasis"""
@@ -239,10 +260,11 @@ class TestBasisEvaluationFourier(unittest.TestCase):
 
             t = np.linspace(0, 1, 4)
 
-            res = np.array([0.905, 0.147, -1.05, 0.905, 0.303, 0.775, -1.024, 0.303]).reshape((2, 4))
+            res = np.array([0.905, 0.147, -1.05, 0.905, 0.303,
+                            0.775, -1.024, 0.303]).reshape((2, 4))
 
-            np.testing.assert_array_equal(f(t).round(3), res)
-            np.testing.assert_array_equal(f.evaluate(t).round(3), res)
+            np.testing.assert_array_almost_equal(f(t).round(3), res)
+            np.testing.assert_array_almost_equal(f.evaluate(t).round(3), res)
 
 
 class TestBasisEvaluationBSpline(unittest.TestCase):
@@ -261,8 +283,8 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         res = np.array([[0.001, 0.564, 0.435, 0.33],
                         [0.018, 0.468, 0.371, 0.12]])
 
-        np.testing.assert_array_equal(f(t).round(3), res)
-        np.testing.assert_array_equal(f.evaluate(t).round(3), res)
+        np.testing.assert_array_almost_equal(f(t).round(3), res)
+        np.testing.assert_array_almost_equal(f.evaluate(t).round(3), res)
 
     def test_evaluation_point_bspline(self):
         """Test the evaluation of a single point FDataBasis"""
@@ -276,13 +298,13 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         # Test different ways of call f with a point
         res = np.array([[0.5696], [0.3104]])
 
-        np.testing.assert_array_equal(f([0.5]).round(4), res)
-        np.testing.assert_array_equal(f((0.5,)).round(4), res)
-        np.testing.assert_array_equal(f(0.5).round(4), res)
-        np.testing.assert_array_equal(f(np.array([0.5])).round(4), res)
+        np.testing.assert_array_almost_equal(f([0.5]).round(4), res)
+        np.testing.assert_array_almost_equal(f((0.5,)).round(4), res)
+        np.testing.assert_array_almost_equal(f(0.5).round(4), res)
+        np.testing.assert_array_almost_equal(f(np.array([0.5])).round(4), res)
 
         # Problematic case, should be accepted or no?
-        #np.testing.assert_array_equal(f(np.array(0.5)).round(4), res)
+        #np.testing.assert_array_almost_equal(f(np.array(0.5)).round(4), res)
 
     def test_evaluation_derivative_bspline(self):
         """Test the evaluation of the derivative of a FDataBasis"""
@@ -295,7 +317,7 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             f(t, derivative=1).round(3),
             np.array([[2.927,  0.453, -1.229,  0.6],
                       [4.3, -1.599,  1.016, -2.52]])
@@ -316,10 +338,11 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         res_test = f(t)
 
         # Different ways to pass the axes
-        np.testing.assert_array_equal(f(t, grid=True), res_test)
-        np.testing.assert_array_equal(f((t,), grid=True), res_test)
-        np.testing.assert_array_equal(f([t], grid=True), res_test)
-        np.testing.assert_array_equal(f(np.atleast_2d(t), grid=True), res_test)
+        np.testing.assert_array_almost_equal(f(t, grid=True), res_test)
+        np.testing.assert_array_almost_equal(f((t,), grid=True), res_test)
+        np.testing.assert_array_almost_equal(f([t], grid=True), res_test)
+        np.testing.assert_array_almost_equal(
+            f(np.atleast_2d(t), grid=True), res_test)
 
         # Number of axis different than the domain dimension (1)
         with np.testing.assert_raises(ValueError):
@@ -339,20 +362,20 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         res_test = f(t)
 
         # Test same result than evaluation standart
-        np.testing.assert_array_equal(f([1]), f([[1], [1]],
-                                                aligned_evaluation=False))
-        np.testing.assert_array_equal(f(t), f(np.vstack((t, t)),
-                                              aligned_evaluation=False))
+        np.testing.assert_array_almost_equal(f([1]),
+                                             f([[1], [1]],
+                                               aligned_evaluation=False))
+        np.testing.assert_array_almost_equal(f(t), f(np.vstack((t, t)),
+                                                     aligned_evaluation=False))
 
         # Different evaluation times
         t_multiple = [[0, 0.5], [0.2, 0.7]]
-        np.testing.assert_array_equal(f(t_multiple[0])[0],
-                                      f(t_multiple,
-                                        aligned_evaluation=False)[0])
-        np.testing.assert_array_equal(f(t_multiple[1])[1],
-                                      f(t_multiple,
-                                        aligned_evaluation=False)[1])
-
+        np.testing.assert_array_almost_equal(f(t_multiple[0])[0],
+                                             f(t_multiple,
+                                               aligned_evaluation=False)[0])
+        np.testing.assert_array_almost_equal(f(t_multiple[1])[1],
+                                             f(t_multiple,
+                                               aligned_evaluation=False)[1])
 
     def test_evaluation_keepdims_bspline(self):
         """Test behaviour of keepdims """
@@ -375,17 +398,21 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         res_keepdims = res.reshape((2, 4, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t).round(3), res)
-        np.testing.assert_array_equal(f(t, keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f(t, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f(t).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f(t, keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, keepdims=True).round(3),
+                                             res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t).round(3), res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, keepdims=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f_keepdims(t, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t).round(3), res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t, keepdims=False
+                                                        ).round(3),
+                                             res)
+        np.testing.assert_array_almost_equal(f_keepdims(t, keepdims=True
+                                                        ).round(3),
+                                             res_keepdims)
 
     def test_evaluation_composed_keepdims_bspline(self):
         """Test behaviour of keepdims with composed evaluation"""
@@ -405,26 +432,27 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         res_keepdims = res.reshape((2, 3, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
-                                        keepdims=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
-                                        keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False
+                                               ).round(3),
+                                             res)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
+                                               keepdims=False).round(3),
+                                             res)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
+                                               keepdims=True).round(3),
+                                             res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t,
-                                                 aligned_evaluation=False
-                                                 ).round(3),
-                                      res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False,
-                                                 keepdims=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False,
-                                                 keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t,
+                                                        aligned_evaluation=False
+                                                        ).round(3),
+                                             res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, aligned_evaluation=False, keepdims=False).round(3),
+            res)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, aligned_evaluation=False, keepdims=True).round(3),
+            res_keepdims)
 
     def test_evaluation_grid_keepdims_bspline(self):
         """Test behaviour of keepdims with grid evaluation"""
@@ -448,21 +476,22 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
         res_keepdims = res.reshape((2, 4, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t, grid=True).round(3), res)
-        np.testing.assert_array_equal(f(t, grid=True, keepdims=False).round(3),
-                                      res)
+        np.testing.assert_array_almost_equal(f(t, grid=True).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f(t, grid=True, keepdims=False).round(3), res)
 
-        np.testing.assert_array_equal(f(t,  grid=True, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f(t,  grid=True, keepdims=True).round(3),
+            res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t, grid=True).round(3),
-                                      res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, grid=True,
-                                                 keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f_keepdims(t, grid=True,
-                                                 keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t, grid=True).round(3),
+                                             res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, grid=True, keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, grid=True, keepdims=True).round(3),
+            res_keepdims)
 
     def test_domain_in_list_bspline(self):
         """Test the evaluation of FDataBasis"""
@@ -485,8 +514,8 @@ class TestBasisEvaluationBSpline(unittest.TestCase):
             res = np.array([[0.001, 0.564, 0.435, 0.33],
                             [0.018, 0.468, 0.371, 0.12]])
 
-            np.testing.assert_array_equal(f(t).round(3), res)
-            np.testing.assert_array_equal(f.evaluate(t).round(3), res)
+            np.testing.assert_array_almost_equal(f(t).round(3), res)
+            np.testing.assert_array_almost_equal(f.evaluate(t).round(3), res)
 
         # Check error
         with np.testing.assert_raises(ValueError):
@@ -509,8 +538,8 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         res = np.array([[1., 2., 3.667, 6.],
                         [0.5, 1.111, 2.011, 3.2]])
 
-        np.testing.assert_array_equal(f(t).round(3), res)
-        np.testing.assert_array_equal(f.evaluate(t).round(3), res)
+        np.testing.assert_array_almost_equal(f(t).round(3), res)
+        np.testing.assert_array_almost_equal(f.evaluate(t).round(3), res)
 
     def test_evaluation_point_monomial(self):
         """Test the evaluation of a single point FDataBasis"""
@@ -523,13 +552,13 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         # Test different ways of call f with a point
         res = np.array([[2.75], [1.525]])
 
-        np.testing.assert_array_equal(f([0.5]).round(4), res)
-        np.testing.assert_array_equal(f((0.5,)).round(4), res)
-        np.testing.assert_array_equal(f(0.5).round(4), res)
-        np.testing.assert_array_equal(f(np.array([0.5])).round(4), res)
+        np.testing.assert_array_almost_equal(f([0.5]).round(4), res)
+        np.testing.assert_array_almost_equal(f((0.5,)).round(4), res)
+        np.testing.assert_array_almost_equal(f(0.5).round(4), res)
+        np.testing.assert_array_almost_equal(f(np.array([0.5])).round(4), res)
 
         # Problematic case, should be accepted or no?
-        #np.testing.assert_array_equal(f(np.array(0.5)).round(4), res)
+        #np.testing.assert_array_almost_equal(f(np.array(0.5)).round(4), res)
 
     def test_evaluation_derivative_monomial(self):
         """Test the evaluation of the derivative of a FDataBasis"""
@@ -541,7 +570,7 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
 
         t = np.linspace(0, 1, 4)
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             f(t, derivative=1).round(3),
             np.array([[2., 4., 6., 8.],
                       [1.4, 2.267, 3.133, 4.]])
@@ -561,10 +590,11 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         res_test = f(t)
 
         # Different ways to pass the axes
-        np.testing.assert_array_equal(f(t, grid=True), res_test)
-        np.testing.assert_array_equal(f((t,), grid=True), res_test)
-        np.testing.assert_array_equal(f([t], grid=True), res_test)
-        np.testing.assert_array_equal(f(np.atleast_2d(t), grid=True), res_test)
+        np.testing.assert_array_almost_equal(f(t, grid=True), res_test)
+        np.testing.assert_array_almost_equal(f((t,), grid=True), res_test)
+        np.testing.assert_array_almost_equal(f([t], grid=True), res_test)
+        np.testing.assert_array_almost_equal(
+            f(np.atleast_2d(t), grid=True), res_test)
 
         # Number of axis different than the domain dimension (1)
         with np.testing.assert_raises(ValueError):
@@ -583,21 +613,19 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         res_test = f(t)
 
         # Test same result than evaluation standart
-        np.testing.assert_array_equal(f([1]), f([[1], [1]],
-                                                aligned_evaluation=False))
-        np.testing.assert_array_equal(f(t), f(np.vstack((t, t)),
-                                              aligned_evaluation=False))
+        np.testing.assert_array_almost_equal(f([1]), f([[1], [1]],
+                                                       aligned_evaluation=False))
+        np.testing.assert_array_almost_equal(f(t), f(np.vstack((t, t)),
+                                                     aligned_evaluation=False))
 
         # Different evaluation times
         t_multiple = [[0, 0.5], [0.2, 0.7]]
-        np.testing.assert_array_equal(f(t_multiple[0])[0],
-                                      f(t_multiple,
-                                        aligned_evaluation=False)[0])
-        np.testing.assert_array_equal(f(t_multiple[1])[1],
-                                      f(t_multiple,
-                                        aligned_evaluation=False)[1])
-
-
+        np.testing.assert_array_almost_equal(f(t_multiple[0])[0],
+                                             f(t_multiple,
+                                               aligned_evaluation=False)[0])
+        np.testing.assert_array_almost_equal(f(t_multiple[1])[1],
+                                             f(t_multiple,
+                                               aligned_evaluation=False)[1])
 
     def test_evaluation_keepdims_monomial(self):
         """Test behaviour of keepdims """
@@ -619,17 +647,19 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         res_keepdims = res.reshape((2, 4, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t).round(3), res)
-        np.testing.assert_array_equal(f(t, keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f(t, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f(t).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f(t, keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, keepdims=True).round(3),
+                                             res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t).round(3), res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, keepdims=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f_keepdims(t, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t).round(3), res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, keepdims=True).round(3), res_keepdims)
 
     def test_evaluation_composed_keepdims_monomial(self):
         """Test behaviour of keepdims with composed evaluation"""
@@ -648,24 +678,24 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         res_keepdims = res.reshape((2, 3, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
-                                        keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
-                                        keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f(t, aligned_evaluation=False).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
+                                               keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
+                                               keepdims=True).round(3),
+                                             res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False
-                                                 ).round(3),
-                                      res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False,
-                                                 keepdims=False).round(3),
-                                      res)
-        np.testing.assert_array_equal(f_keepdims(t, aligned_evaluation=False,
-                                                 keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, aligned_evaluation=False).round(3),
+            res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, aligned_evaluation=False, keepdims=False).round(3),
+            res)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, aligned_evaluation=False, keepdims=True).round(3),
+            res_keepdims)
 
     def test_evaluation_grid_keepdims_monomial(self):
         """Test behaviour of keepdims with grid evaluation"""
@@ -688,21 +718,21 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
         res_keepdims = res.reshape((2, 4, 1))
 
         # Case default behaviour keepdims=False
-        np.testing.assert_array_equal(f(t, grid=True).round(3), res)
-        np.testing.assert_array_equal(f(t, grid=True, keepdims=False).round(3),
-                                      res)
+        np.testing.assert_array_almost_equal(f(t, grid=True).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f(t, grid=True, keepdims=False).round(3),
+            res)
 
-        np.testing.assert_array_equal(f(t,  grid=True, keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f(t,  grid=True, keepdims=True).round(3), res_keepdims)
 
         # Case default behaviour keepdims=True
-        np.testing.assert_array_equal(f_keepdims(t, grid=True).round(3),
-                                      res_keepdims)
-        np.testing.assert_array_equal(f_keepdims(t, grid=True,
-                                                 keepdims=False).round(3), res)
-        np.testing.assert_array_equal(f_keepdims(t, grid=True,
-                                                 keepdims=True).round(3),
-                                      res_keepdims)
+        np.testing.assert_array_almost_equal(f_keepdims(t, grid=True).round(3),
+                                             res_keepdims)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, grid=True, keepdims=False).round(3), res)
+        np.testing.assert_array_almost_equal(
+            f_keepdims(t, grid=True, keepdims=True).round(3), res_keepdims)
 
     def test_domain_in_list_monomial(self):
         """Test the evaluation of FDataBasis"""
@@ -721,8 +751,8 @@ class TestBasisEvaluationMonomial(unittest.TestCase):
             res = np.array([[1., 2., 3.667, 6.],
                             [0.5, 1.111, 2.011, 3.2]])
 
-            np.testing.assert_array_equal(f(t).round(3), res)
-            np.testing.assert_array_equal(f.evaluate(t).round(3), res)
+            np.testing.assert_array_almost_equal(f(t).round(3), res)
+            np.testing.assert_array_almost_equal(f.evaluate(t).round(3), res)
 
 
 if __name__ == '__main__':

--- a/tests/test_grid_spline_interpolation.py
+++ b/tests/test_grid_spline_interpolation.py
@@ -26,10 +26,11 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         f = FDataGrid(self.data_matrix_1_1, sample_points=np.arange(10))
 
         # Test interpolation in nodes
-        np.testing.assert_array_equal(f(np.arange(10)), self.data_matrix_1_1)
+        np.testing.assert_array_almost_equal(
+            f(np.arange(10)), self.data_matrix_1_1)
 
         # Test evaluation in a list of times
-        np.testing.assert_array_equal(f([0.5,1.5,2.5]),
+        np.testing.assert_array_almost_equal(f([0.5,1.5,2.5]),
                                       np.array([[ 0.5,  2.5,  6.5],
                                                 [72.5, 56.5, 42.5]]))
 
@@ -39,10 +40,10 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         f = FDataGrid(self.data_matrix_1_1, sample_points=np.arange(10))
 
         # Test a single point
-        np.testing.assert_array_equal(f(5.3).round(1),
+        np.testing.assert_array_almost_equal(f(5.3).round(1),
                                       np.array([[28.3], [13.9]]))
-        np.testing.assert_array_equal(f([3]), np.array([[9.], [36.]]))
-        np.testing.assert_array_equal(f((2,)), np.array([[4.], [49.]]))
+        np.testing.assert_array_almost_equal(f([3]), np.array([[9.], [36.]]))
+        np.testing.assert_array_almost_equal(f((2,)), np.array([[4.], [49.]]))
 
 
     def test_evaluation_linear_derivative(self):
@@ -50,7 +51,8 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         f = FDataGrid(self.data_matrix_1_1, sample_points=np.arange(10))
 
         # Derivate = [2*x, 2*(9-x)]
-        np.testing.assert_array_equal(f([0.5,1.5,2.5], derivative=1).round(3),
+        np.testing.assert_array_almost_equal(
+            f([0.5,1.5,2.5], derivative=1).round(3),
                                       np.array([[  1.,   3.,   5.],
                                                 [-17., -15., -13.]]))
 
@@ -60,17 +62,19 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         f = FDataGrid(self.data_matrix_1_1, sample_points=np.arange(10))
 
         # Test interpolation in nodes
-        np.testing.assert_array_equal(f(np.arange(10)), self.data_matrix_1_1)
+        np.testing.assert_array_almost_equal(f(np.arange(10)),
+                                             self.data_matrix_1_1)
 
         res = np.array([[ 0.5,  2.5,  6.5], [72.5, 56.5, 42.5]])
         t = [0.5,1.5,2.5]
 
         # Test evaluation in a list of times
-        np.testing.assert_array_equal(f(t, grid=True), res)
-        np.testing.assert_array_equal(f((t,), grid=True), res)
-        np.testing.assert_array_equal(f([t], grid=True), res)
+        np.testing.assert_array_almost_equal(f(t, grid=True), res)
+        np.testing.assert_array_almost_equal(f((t,), grid=True), res)
+        np.testing.assert_array_almost_equal(f([t], grid=True), res)
         # Single point with grid
-        np.testing.assert_array_equal(f(3, grid=True), np.array([[9.], [36.]]))
+        np.testing.assert_array_almost_equal(f(3, grid=True),
+                                             np.array([[9.], [36.]]))
 
         # Check erroneous axis
         with np.testing.assert_raises(ValueError): f((t,t), grid=True)
@@ -80,18 +84,21 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         f = FDataGrid(self.data_matrix_1_1, sample_points=np.arange(10))
 
         # Evaluate (x**2, (9-x)**2) in (1,8)
-        np.testing.assert_array_equal(f([[1],[8]], aligned_evaluation=False),
+        np.testing.assert_array_almost_equal(f([[1],[8]],
+                                               aligned_evaluation=False),
                                       np.array([[1.], [1.]]))
 
         t = np.linspace(4,6,4)
-        np.testing.assert_array_equal(f([t,9-t], aligned_evaluation=False).round(2),
-                                      np.array([[16.  , 22.  , 28.67, 36.  ],
-                                                [16.  , 22.  , 28.67, 36.  ]]))
+        np.testing.assert_array_almost_equal(
+            f([t,9-t], aligned_evaluation=False).round(2),
+            np.array([[16.  , 22.  , 28.67, 36.  ],
+                      [16.  , 22.  , 28.67, 36.  ]]))
 
         # Same length than nsample
         t = np.linspace(4,6,2)
-        np.testing.assert_array_equal(f([t,9-t], aligned_evaluation=False).round(2),
-                                      np.array([[16.  , 36.], [16.  , 36.]]))
+        np.testing.assert_array_almost_equal(
+            f([t,9-t], aligned_evaluation=False).round(2),
+            np.array([[16.  , 36.], [16.  , 36.]]))
 
     def test_evaluation_linear_keepdims(self):
         """Test parameter keepdims"""
@@ -110,26 +117,26 @@ class TestEvaluationSpline1_1(unittest.TestCase):
 
 
         # Test combinations of keepdims with list
-        np.testing.assert_array_equal(f(t), res)
-        np.testing.assert_array_equal(f(t, keepdims=False), res)
-        np.testing.assert_array_equal(f(t, keepdims=True), res_keepdims)
+        np.testing.assert_array_almost_equal(f(t), res)
+        np.testing.assert_array_almost_equal(f(t, keepdims=False), res)
+        np.testing.assert_array_almost_equal(f(t, keepdims=True), res_keepdims)
 
-        np.testing.assert_array_equal(fk(t), res_keepdims)
-        np.testing.assert_array_equal(fk(t, keepdims=False), res)
-        np.testing.assert_array_equal(fk(t, keepdims=True), res_keepdims)
+        np.testing.assert_array_almost_equal(fk(t), res_keepdims)
+        np.testing.assert_array_almost_equal(fk(t, keepdims=False), res)
+        np.testing.assert_array_almost_equal(fk(t, keepdims=True), res_keepdims)
 
         t2 = 4
         res2 = np.array([[16.], [25.]])
         res2_keepdims = res2.reshape(2,1,1)
 
         # Test combinations of keepdims with a single point
-        np.testing.assert_array_equal(f(t2), res2)
-        np.testing.assert_array_equal(f(t2, keepdims=False), res2)
-        np.testing.assert_array_equal(f(t2, keepdims=True), res2_keepdims)
+        np.testing.assert_array_almost_equal(f(t2), res2)
+        np.testing.assert_array_almost_equal(f(t2, keepdims=False), res2)
+        np.testing.assert_array_almost_equal(f(t2, keepdims=True), res2_keepdims)
 
-        np.testing.assert_array_equal(fk(t2), res2_keepdims)
-        np.testing.assert_array_equal(fk(t2, keepdims=False), res2)
-        np.testing.assert_array_equal(fk(t2, keepdims=True), res2_keepdims)
+        np.testing.assert_array_almost_equal(fk(t2), res2_keepdims)
+        np.testing.assert_array_almost_equal(fk(t2, keepdims=False), res2)
+        np.testing.assert_array_almost_equal(fk(t2, keepdims=True), res2_keepdims)
 
     def test_evaluation_composed_linear_keepdims(self):
         """Test parameter keepdims with composed evaluation"""
@@ -148,17 +155,17 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         res_keepdims = res.reshape((2,3,1))
 
         # Test combinations of keepdims with list
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False), res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False), res)
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
                                         keepdims=False), res)
-        np.testing.assert_array_equal(f(t, aligned_evaluation=False,
+        np.testing.assert_array_almost_equal(f(t, aligned_evaluation=False,
                                         keepdims=True), res_keepdims)
 
-        np.testing.assert_array_equal(fk(t, aligned_evaluation=False),
+        np.testing.assert_array_almost_equal(fk(t, aligned_evaluation=False),
                                       res_keepdims)
-        np.testing.assert_array_equal(fk(t, aligned_evaluation=False,
+        np.testing.assert_array_almost_equal(fk(t, aligned_evaluation=False,
                                          keepdims=False), res)
-        np.testing.assert_array_equal(fk(t, aligned_evaluation=False,
+        np.testing.assert_array_almost_equal(fk(t, aligned_evaluation=False,
                                          keepdims=True), res_keepdims)
 
     def test_evaluation_grid_linear_keepdims(self):
@@ -176,15 +183,15 @@ class TestEvaluationSpline1_1(unittest.TestCase):
         res = np.array([[ 0.5,  2.5,  6.5], [72.5, 56.5, 42.5]])
         res_keepdims = res.reshape(2,3,1)
 
-        np.testing.assert_array_equal(f(t, grid=True), res)
-        np.testing.assert_array_equal(f((t,), grid=True, keepdims=True),
+        np.testing.assert_array_almost_equal(f(t, grid=True), res)
+        np.testing.assert_array_almost_equal(f((t,), grid=True, keepdims=True),
                                       res_keepdims)
-        np.testing.assert_array_equal(f([t], grid=True, keepdims=False), res)
+        np.testing.assert_array_almost_equal(f([t], grid=True, keepdims=False), res)
 
-        np.testing.assert_array_equal(fk(t, grid=True), res_keepdims)
-        np.testing.assert_array_equal(fk((t,), grid=True, keepdims=True),
+        np.testing.assert_array_almost_equal(fk(t, grid=True), res_keepdims)
+        np.testing.assert_array_almost_equal(fk((t,), grid=True, keepdims=True),
                                       res_keepdims)
-        np.testing.assert_array_equal(fk([t], grid=True, keepdims=False), res)
+        np.testing.assert_array_almost_equal(fk([t], grid=True, keepdims=False), res)
 
     def test_evaluation_cubic_simple(self):
         """Test basic usage of evaluation"""
@@ -193,11 +200,11 @@ class TestEvaluationSpline1_1(unittest.TestCase):
                       interpolator=GridSplineInterpolator(3))
 
         # Test interpolation in nodes
-        np.testing.assert_array_equal(f(np.arange(10)).round(1),
+        np.testing.assert_array_almost_equal(f(np.arange(10)).round(1),
                                       self.data_matrix_1_1)
 
         # Test evaluation in a list of times
-        np.testing.assert_array_equal(f([0.5,1.5,2.5]).round(2),
+        np.testing.assert_array_almost_equal(f([0.5,1.5,2.5]).round(2),
                                       np.array([[ 0.25,  2.25,  6.25],
                                                 [72.25, 56.25, 42.25]]))
 
@@ -208,11 +215,11 @@ class TestEvaluationSpline1_1(unittest.TestCase):
                       interpolator=GridSplineInterpolator(3))
 
         # Test a single point
-        np.testing.assert_array_equal(f(5.3).round(3), np.array([[28.09],
+        np.testing.assert_array_almost_equal(f(5.3).round(3), np.array([[28.09],
                                                                  [13.69]]))
 
-        np.testing.assert_array_equal(f([3]).round(3), np.array([[9.], [36.]]))
-        np.testing.assert_array_equal(f((2,)).round(3), np.array([[4.], [49.]]))
+        np.testing.assert_array_almost_equal(f([3]).round(3), np.array([[9.], [36.]]))
+        np.testing.assert_array_almost_equal(f((2,)).round(3), np.array([[4.], [49.]]))
 
 
     def test_evaluation_cubic_derivative(self):
@@ -221,7 +228,7 @@ class TestEvaluationSpline1_1(unittest.TestCase):
                       interpolator=GridSplineInterpolator(3))
 
         # Derivate = [2*x, 2*(9-x)]
-        np.testing.assert_array_equal(f([0.5,1.5,2.5], derivative=1).round(3),
+        np.testing.assert_array_almost_equal(f([0.5,1.5,2.5], derivative=1).round(3),
                                       np.array([[  1.,   3.,   5.],
                                                 [-17., -15., -13.]]))
 
@@ -236,11 +243,11 @@ class TestEvaluationSpline1_1(unittest.TestCase):
 
 
         # Test evaluation in a list of times
-        np.testing.assert_array_equal(f(t, grid=True).round(3), res)
-        np.testing.assert_array_equal(f((t,), grid=True).round(3), res)
-        np.testing.assert_array_equal(f([t], grid=True).round(3), res)
+        np.testing.assert_array_almost_equal(f(t, grid=True).round(3), res)
+        np.testing.assert_array_almost_equal(f((t,), grid=True).round(3), res)
+        np.testing.assert_array_almost_equal(f([t], grid=True).round(3), res)
         # Single point with grid
-        np.testing.assert_array_equal(f(3, grid=True), np.array([[9.], [36.]]))
+        np.testing.assert_array_almost_equal(f(3, grid=True), np.array([[9.], [36.]]))
 
         # Check erroneous axis
         with np.testing.assert_raises(ValueError): f((t,t), grid=True)
@@ -252,17 +259,17 @@ class TestEvaluationSpline1_1(unittest.TestCase):
 
 
         # Evaluate (x**2, (9-x)**2) in (1,8)
-        np.testing.assert_array_equal(f([[1],[8]], aligned_evaluation=False).round(3)
+        np.testing.assert_array_almost_equal(f([[1],[8]], aligned_evaluation=False).round(3)
                                       ,np.array([[1.], [1.]]))
 
         t = np.linspace(4,6,4)
-        np.testing.assert_array_equal(f([t,9-t], aligned_evaluation=False).round(2),
+        np.testing.assert_array_almost_equal(f([t,9-t], aligned_evaluation=False).round(2),
                                       np.array([[16.  , 21.78, 28.44, 36.  ],
                                                 [16.  , 21.78, 28.44, 36.  ]]))
 
         # Same length than nsample
         t = np.linspace(4,6,2)
-        np.testing.assert_array_equal(f([t,9-t], aligned_evaluation=False).round(3),
+        np.testing.assert_array_almost_equal(f([t,9-t], aligned_evaluation=False).round(3),
                                       np.array([[16.  , 36.], [16.  , 36.]]))
 
     def test_evaluation_nodes(self):
@@ -275,7 +282,7 @@ class TestEvaluationSpline1_1(unittest.TestCase):
                           interpolator=interpolator)
 
             # Test interpolation in nodes
-            np.testing.assert_array_equal(f(np.arange(10)).round(5),
+            np.testing.assert_array_almost_equal(f(np.arange(10)).round(5),
                                           self.data_matrix_1_1)
 
     def test_error_degree(self):
@@ -410,11 +417,11 @@ class TestEvaluationSpline1_n(unittest.TestCase):
 
         res = f(self.t)
         # Test interpolation in nodes
-        np.testing.assert_array_equal(f(self.t, keepdims=False), res)
-        np.testing.assert_array_equal(f(self.t, keepdims=True), res)
-        np.testing.assert_array_equal(fk(self.t), res)
-        np.testing.assert_array_equal(fk(self.t, keepdims=False), res)
-        np.testing.assert_array_equal(fk(self.t, keepdims=True), res)
+        np.testing.assert_array_almost_equal(f(self.t, keepdims=False), res)
+        np.testing.assert_array_almost_equal(f(self.t, keepdims=True), res)
+        np.testing.assert_array_almost_equal(fk(self.t), res)
+        np.testing.assert_array_almost_equal(fk(self.t, keepdims=False), res)
+        np.testing.assert_array_almost_equal(fk(self.t, keepdims=True), res)
 
 
     def test_evaluation_nodes(self):


### PR DESCRIPTION
Depending on the numpy version, there may be slight changes in the results that can cause the tests to fail by using `round` and `array_equal` which can be avoided using `array_almost_equal`. See #78.

Changes:
* `array_equal` -> `array_almost_equal`
* Changes in code indentation to follow PEP8